### PR TITLE
Use given price instead of response from create order

### DIFF
--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -257,7 +257,7 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         _order = self.store.fetch_order(ret_ord['id'], data.p.dataname)
 
         order = CCXTOrder(owner, data, _order)
-        order.price = ret_ord['price']
+        order.price = price
         self.open_orders.append(order)
 
         self.notify(order)


### PR DESCRIPTION
create_order doesn't contain a reliable source of the price used to create the order